### PR TITLE
chore: Apply coveralls

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,9 @@ script: "./gradlew clean build"
 notifications:
     slack: woowahan-techcamp:DUmMgWkADZU9aC7hhTK2HPZc
 
+after_success:
+- ./gradlew jacocoTestReport coveralls
+
 before_deploy:
 - zip -r recipehub-develop *
 - mkdir -p deploy

--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
 # team5-fiveMasterGuys
 5팀 프로젝트 저장소
 [![Build Status](https://travis-ci.org/wwh-techcamp-2018/team5-fiveMasterGuys.svg?branch=master)](https://travis-ci.org/wwh-techcamp-2018/team5-fiveMasterGuys)
+[![Coverage Status](https://coveralls.io/repos/github/wwh-techcamp-2018/team5-fiveMasterGuys/badge.svg?branch=develop)](https://coveralls.io/github/wwh-techcamp-2018/team5-fiveMasterGuys?branch=develop)

--- a/build.gradle
+++ b/build.gradle
@@ -7,6 +7,7 @@ buildscript {
 	}
 	dependencies {
 		classpath("org.springframework.boot:spring-boot-gradle-plugin:${springBootVersion}")
+		classpath 'org.kt3k.gradle.plugin:coveralls-gradle-plugin:2.8.2'
 	}
 }
 
@@ -14,6 +15,10 @@ apply plugin: 'java'
 apply plugin: 'eclipse'
 apply plugin: 'org.springframework.boot'
 apply plugin: 'io.spring.dependency-management'
+
+// for code test coverage
+apply plugin: 'jacoco'
+apply plugin: 'com.github.kt3k.coveralls'
 
 group = 'com.woowahan.techcamp'
 version = '0.0.1-SNAPSHOT'
@@ -23,6 +28,12 @@ repositories {
 	mavenCentral()
 }
 
+jacocoTestReport {
+	reports {
+		xml.enabled = true // coveralls plugin depends on xml format report
+		html.enabled = true
+	}
+}
 
 dependencies {
 	compile('org.springframework.boot:spring-boot-starter-data-jpa')


### PR DESCRIPTION
코드 커버리지 적용합니다.

Gradle Build시, 코드 커버리지를 측정하고 이 결과를 coveralls.io로 전송합니다.
코드 커버리지 측정하는 도구는 jacoco 등 여러가지가 있구요.
마찬가지로 측정된 데이터를 보여주는 사이트 또한 coveralls.io 말고 여러곳이 있어요.

코드 커버리지에 관련된건 아래 포스팅을 읽어보시는것을 추천 드려요.
지표는 언제나 진행상황을 예측할 수 있게 만들어줘서 좋은거 같아요🤓

https://blog.outsider.ne.kr/954
https://nesoy.github.io/articles/2018-01/Code-Coverage (이건 가볍게 보시길)
