### PR TITLE
feat: Add request client for Web AcceptanceTest

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -46,6 +46,9 @@ dependencies {
 	runtime('mysql:mysql-connector-java:8.0.12')
 	runtime('com.h2database:h2')
 	compileOnly('org.projectlombok:lombok')
+
+	// Refer: https://github.com/spring-projects/spring-security-oauth/issues/441#issuecomment-345188476
+	testCompile('org.apache.httpcomponents:httpclient')
 	testCompile('org.assertj:assertj-core:3.10.0')
 	testCompile('org.springframework.boot:spring-boot-starter-test')
 }

--- a/src/main/java/com/woowahan/techcamp/recipehub/common/exception/BadRequestException.java
+++ b/src/main/java/com/woowahan/techcamp/recipehub/common/exception/BadRequestException.java
@@ -1,0 +1,9 @@
+package com.woowahan.techcamp.recipehub.common.exception;
+
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+@ResponseStatus(HttpStatus.BAD_REQUEST)
+public class BadRequestException extends RuntimeException {
+}

--- a/src/main/java/com/woowahan/techcamp/recipehub/common/support/APIControllerAdvice.java
+++ b/src/main/java/com/woowahan/techcamp/recipehub/common/support/APIControllerAdvice.java
@@ -1,0 +1,56 @@
+package com.woowahan.techcamp.recipehub.common.support;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.context.support.MessageSourceAccessor;
+import org.springframework.http.HttpStatus;
+import org.springframework.validation.FieldError;
+import org.springframework.validation.ObjectError;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import javax.annotation.Resource;
+import java.util.List;
+import java.util.Optional;
+
+@RestControllerAdvice
+public class APIControllerAdvice {
+    private static final Logger log = LoggerFactory.getLogger(APIControllerAdvice.class);
+
+    @Resource(name = "messageSourceAccessor")
+    private MessageSourceAccessor messageSourceAccessor;
+
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    public RestResponse<?> handleValidationException(MethodArgumentNotValidException exception) {
+        List<ObjectError> errors = exception.getBindingResult().getAllErrors();
+        RestResponse.ErrorResponseBuilder errorResponseBuilder = RestResponse.error();
+        for (ObjectError objectError : errors) {
+            log.debug("object error : {}", objectError);
+            FieldError fieldError = (FieldError) objectError;
+            errorResponseBuilder.appendError(fieldError.getField(), getErrorMessage(fieldError));
+        }
+        return errorResponseBuilder.build();
+    }
+
+    private String getErrorMessage(FieldError fieldError) {
+        Optional<String> code = getFirstCode(fieldError);
+        if (!code.isPresent()) {
+            return null;
+        }
+
+        String errorMessage = messageSourceAccessor.getMessage(code.get(), fieldError.getArguments(), fieldError.getDefaultMessage());
+        log.info("error message: {}", errorMessage);
+        return errorMessage;
+    }
+
+    private Optional<String> getFirstCode(FieldError fieldError) {
+        String[] codes = fieldError.getCodes();
+        if (codes == null || codes.length == 0) {
+            return Optional.empty();
+        }
+        return Optional.of(codes[0]);
+    }
+}

--- a/src/main/java/com/woowahan/techcamp/recipehub/common/support/WebControllerAdvice.java
+++ b/src/main/java/com/woowahan/techcamp/recipehub/common/support/WebControllerAdvice.java
@@ -1,0 +1,36 @@
+package com.woowahan.techcamp.recipehub.common.support;
+
+import com.woowahan.techcamp.recipehub.common.exception.BadRequestException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.HttpStatus;
+import org.springframework.validation.BindException;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.servlet.ModelAndView;
+
+import javax.persistence.EntityNotFoundException;
+
+@ControllerAdvice
+public class WebControllerAdvice {
+    private static final Logger log = LoggerFactory.getLogger(WebControllerAdvice.class);
+
+    @ExceptionHandler(BindException.class)
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    public ModelAndView handleError(BindException exception) {
+        return new ModelAndView("redirect:/");
+    }
+
+    @ExceptionHandler(BadRequestException.class)
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    public ModelAndView handleBadRequest(BadRequestException exception) {
+        return new ModelAndView("redirect:/");
+    }
+
+    @ExceptionHandler(EntityNotFoundException.class)
+    @ResponseStatus(HttpStatus.NOT_FOUND)
+    public String handleNotFound(EntityNotFoundException exception) {
+        return "/notfound";
+    }
+}

--- a/src/main/resources/templates/notfound.hbs
+++ b/src/main/resources/templates/notfound.hbs
@@ -1,0 +1,9 @@
+{{#partial "contents"}}
+    <section class="section">
+        <div class="container">
+            404. Not Found.
+        </div>
+    </section>
+{{/partial}}
+
+{{>base}}

--- a/src/test/java/com/woowahan/techcamp/recipehub/support/AcceptanceTest.java
+++ b/src/test/java/com/woowahan/techcamp/recipehub/support/AcceptanceTest.java
@@ -18,10 +18,14 @@ import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
 import org.springframework.web.context.WebApplicationContext;
 
 import java.io.IOException;
+import java.util.Arrays;
 import java.util.List;
+import java.util.Map;
 
 @RunWith(SpringRunner.class)
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
@@ -40,13 +44,19 @@ public abstract class AcceptanceTest {
     protected MockMvc mvc;
     protected final String DEFAULT_USER_EMAIL = "WeAreTheBestTeam@recipehub.com";
     protected final String DEFAULT_USER_PASSWORD = "password1234!";
+    protected User basicAuthUser;
+    protected User savedUser;
 
     @Before
     public void setUp() throws Exception {
-        userRepository.save(User.builder()
+        User.UserBuilder userBuilder = User.builder()
                 .email(DEFAULT_USER_EMAIL)
                 .password(new BCryptPasswordEncoder().encode(DEFAULT_USER_PASSWORD))
-                .name("Team5").build());
+                .name("Team5");
+        savedUser = userRepository.save(userBuilder.build());
+
+        basicAuthUser = userBuilder.password(DEFAULT_USER_PASSWORD).build();
+
         mvc = MockMvcBuilders
                 .webAppContextSetup(context)
                 .build();
@@ -61,34 +71,90 @@ public abstract class AcceptanceTest {
         return (user == null) ? template : template.withBasicAuth(user.getEmail(), user.getPassword());
     }
 
-    private HttpHeaders getHeaders() {
+    private HttpHeaders getJsonHeaders() {
         HttpHeaders headers = new HttpHeaders();
         headers.setContentType(MediaType.APPLICATION_JSON);
         return headers;
     }
 
-    protected <T, R> ResponseEntity<RestResponse<R>> request(String path, HttpMethod method, T dto, User user, ParameterizedTypeReference<RestResponse<R>> typeRef) {
-        return template(user).exchange(path, method, new HttpEntity<>(dto, getHeaders()), typeRef);
+    private HttpHeaders getHeaders() {
+        HttpHeaders headers = new HttpHeaders();
+        headers.setAccept(Arrays.asList(MediaType.TEXT_HTML));
+        headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
+        return headers;
     }
 
-    protected <T, R> ResponseEntity<RestResponse<R>> request(String path, HttpMethod method, T dto, ParameterizedTypeReference<RestResponse<R>> typeRef) {
-        return request(path, method, dto, null, typeRef);
+    protected <T, R> ResponseEntity<RestResponse<R>> requestJson(String path, HttpMethod method, T dto, User user, ParameterizedTypeReference<RestResponse<R>> typeRef) {
+        return template(user).exchange(path, method, new HttpEntity<>(dto, getJsonHeaders()), typeRef);
     }
 
-    protected <T, R> ResponseEntity<RestResponse<R>> request(String path, HttpMethod method, ParameterizedTypeReference<RestResponse<R>> typeRef) {
-        return request(path, method, null, null, typeRef);
+    protected <T, R> ResponseEntity<RestResponse<R>> requestJson(String path, HttpMethod method, T dto, ParameterizedTypeReference<RestResponse<R>> typeRef) {
+        return requestJson(path, method, dto, null, typeRef);
     }
 
-    protected <T, R> ResponseEntity<RestResponse<List<R>>> requestList(String path, HttpMethod method, T dto, User user, ParameterizedTypeReference<RestResponse<List<R>>> typeRef) {
-        return template(user).exchange(path, method, new HttpEntity<>(dto, getHeaders()), typeRef);
+    protected <R> ResponseEntity<RestResponse<R>> requestJson(String path, HttpMethod method, ParameterizedTypeReference<RestResponse<R>> typeRef) {
+        return requestJson(path, method, null, null, typeRef);
     }
 
-    protected <T, R> ResponseEntity<RestResponse<List<R>>> requestList(String path, HttpMethod method, T dto, ParameterizedTypeReference<RestResponse<List<R>>> typeRef) {
-        return requestList(path, method, dto, null, typeRef);
+    protected <T, R> ResponseEntity<RestResponse<List<R>>> requestJsonList(String path, HttpMethod method, T dto, User user, ParameterizedTypeReference<RestResponse<List<R>>> typeref) {
+        return template(user).exchange(path, method, new HttpEntity<>(dto, getJsonHeaders()), typeref);
     }
 
-    protected <T, R> ResponseEntity<RestResponse<List<R>>> requestList(String path, HttpMethod method, ParameterizedTypeReference<RestResponse<List<R>>> typeRef) {
-        return requestList(path, method, null, null, typeRef);
+    protected <T, R> ResponseEntity<RestResponse<List<R>>> requestJsonList(String path, HttpMethod method, T dto, ParameterizedTypeReference<RestResponse<List<R>>> typeRef) {
+        return requestJsonList(path, method, dto, null, typeRef);
+    }
+
+    protected <R> ResponseEntity<RestResponse<List<R>>> requestJsonList(String path, HttpMethod method, ParameterizedTypeReference<RestResponse<List<R>>> typeRef) {
+        return requestJsonList(path, method, null, null, typeRef);
+    }
+
+    protected ResponseEntity<String> requestGet(String path, User user) {
+        return template(user).getForEntity(path, String.class);
+    }
+
+    protected ResponseEntity<String> requestGet(String path) {
+        return template(null).getForEntity(path, String.class);
+    }
+
+    protected <T> ResponseEntity<String> requestPost(String path, T dto, User user) {
+        return template(user).postForEntity(path, request(dto, null), String.class);
+    }
+
+    protected <T> ResponseEntity<String> requestPost(String path, T dto) {
+        return requestPost(path, dto, null);
+    }
+
+    protected <T> ResponseEntity<String> requestPut(String path, T dto, User user) {
+        return template(user).postForEntity(path, request(dto, "put"), String.class);
+    }
+
+    protected <T> ResponseEntity<String> requestPut(String path, T dto) {
+        return requestPut(path, dto, null);
+    }
+
+    protected ResponseEntity<String> requestDelete(String path, User user) {
+        return template(user).postForEntity(path, request(null, "delete"), String.class);
+    }
+
+    protected ResponseEntity<String> requestDelete(String path) {
+        return requestDelete(path, null);
+    }
+
+    private <T> HttpEntity<MultiValueMap<String, Object>> request(T dto, String method) {
+        MultiValueMap<String, Object> params = getBodyParams(dto);
+        if (method != null) params.add("_method", method);
+        return new HttpEntity<>(params, getHeaders());
+    }
+
+    private MultiValueMap<String, Object> getBodyParams(Object dto) {
+        MultiValueMap<String, Object> params = new LinkedMultiValueMap<>();
+        if(dto == null) return params;
+        ObjectMapper mapper = new ObjectMapper();
+        Map<String, Object> map = mapper.convertValue(dto, Map.class);
+        map.entrySet().stream()
+                .filter(e -> e.getValue() != null)
+                .forEach(e -> params.add(e.getKey(), String.valueOf(e.getValue())));
+        return params;
     }
 
     protected static byte[] convertObjectToJsonBytes(Object object) throws IOException {


### PR DESCRIPTION
```
org.springframework.web.client.ResourceAccessException:  I/O error on POST request for "http://localhost:33276/recipes": 
cannot retry due to server authentication, in streaming mode; 
nested exception is java.net.HttpRetryException: cannot retry due to server authentication, in streaming mode
```

커밋 내용 중 Refer에 관련한 링크 내용은요.
Acceptance 테 스트 도중 `@ResponseStatus(HttpStatus.UNAUTHORIZED)`로 401 권한 없음을 내려보내면,

Spring의 기본 restTemplate 클라이언트가 401을 잡지 못하고 위와 같은 ResourceAccessException을 내 뱉는 현상이 있어서, gradle에 apache 클라이언트를 넣고 대체해서 해결하는 방법을 적용했어요~

다른건 안그러는데 딱 401만 그러네요..흠흠. 이 내용은 별로 중요한거 아니니 대충 넘어가셔도 됩니다ㅋㅋㅋ