### PR TITLE
fix: Add annotations to separate web and api exception handling

### DIFF
--- a/src/main/java/com/woowahan/techcamp/recipehub/common/exception/ResourceExistsException.java
+++ b/src/main/java/com/woowahan/techcamp/recipehub/common/exception/ResourceExistsException.java
@@ -4,5 +4,8 @@ import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.ResponseStatus;
 
 @ResponseStatus(HttpStatus.BAD_REQUEST)
-public class ConflictException extends RuntimeException {
+public class ResourceExistsException extends RuntimeException {
+    public ResourceExistsException(String message) {
+        super(message);
+    }
 }

--- a/src/main/java/com/woowahan/techcamp/recipehub/common/support/APIControllerAdvice.java
+++ b/src/main/java/com/woowahan/techcamp/recipehub/common/support/APIControllerAdvice.java
@@ -1,7 +1,8 @@
 package com.woowahan.techcamp.recipehub.common.support;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import com.woowahan.techcamp.recipehub.common.exception.BadRequestException;
+import com.woowahan.techcamp.recipehub.common.exception.ResourceExistsException;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.support.MessageSourceAccessor;
 import org.springframework.http.HttpStatus;
 import org.springframework.validation.FieldError;
@@ -9,15 +10,16 @@ import org.springframework.validation.ObjectError;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
 import javax.annotation.Resource;
 import java.util.List;
 import java.util.Optional;
 
-@RestControllerAdvice
+@Slf4j
+@RestControllerAdvice(annotations = RestController.class)
 public class APIControllerAdvice {
-    private static final Logger log = LoggerFactory.getLogger(APIControllerAdvice.class);
 
     @Resource(name = "messageSourceAccessor")
     private MessageSourceAccessor messageSourceAccessor;
@@ -33,6 +35,15 @@ public class APIControllerAdvice {
             errorResponseBuilder.appendError(fieldError.getField(), getErrorMessage(fieldError));
         }
         return errorResponseBuilder.build();
+    }
+
+    @ExceptionHandler(ResourceExistsException.class)
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    public RestResponse<?> handleResourceExistsException(BadRequestException exception) {
+        RestResponse.ErrorResponseBuilder errorResponseBuilder = RestResponse.error();
+        errorResponseBuilder.appendError(exception.getMessage());
+        return errorResponseBuilder.build();
+
     }
 
     private String getErrorMessage(FieldError fieldError) {

--- a/src/main/java/com/woowahan/techcamp/recipehub/common/support/WebControllerAdvice.java
+++ b/src/main/java/com/woowahan/techcamp/recipehub/common/support/WebControllerAdvice.java
@@ -2,9 +2,9 @@ package com.woowahan.techcamp.recipehub.common.support;
 
 import com.woowahan.techcamp.recipehub.common.exception.BadRequestException;
 import com.woowahan.techcamp.recipehub.common.exception.UnauthorizedException;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Controller;
 import org.springframework.validation.BindException;
 import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
@@ -13,9 +13,9 @@ import org.springframework.web.servlet.ModelAndView;
 
 import javax.persistence.EntityNotFoundException;
 
-@ControllerAdvice
+@Slf4j
+@ControllerAdvice(annotations = Controller.class)
 public class WebControllerAdvice {
-    private static final Logger log = LoggerFactory.getLogger(WebControllerAdvice.class);
 
     @ExceptionHandler(BindException.class)
     @ResponseStatus(HttpStatus.BAD_REQUEST)

--- a/src/main/java/com/woowahan/techcamp/recipehub/user/service/UserService.java
+++ b/src/main/java/com/woowahan/techcamp/recipehub/user/service/UserService.java
@@ -1,6 +1,6 @@
 package com.woowahan.techcamp.recipehub.user.service;
 
-import com.woowahan.techcamp.recipehub.common.exception.ConflictException;
+import com.woowahan.techcamp.recipehub.common.exception.ResourceExistsException;
 import com.woowahan.techcamp.recipehub.common.exception.UnauthorizedException;
 import com.woowahan.techcamp.recipehub.user.domain.User;
 import com.woowahan.techcamp.recipehub.user.dto.LoginDTO;
@@ -20,7 +20,7 @@ public class UserService {
 
     public User create(SignupDTO dto) {
         if (userRepository.existsByEmail(dto.getEmail())) {
-            throw new ConflictException();
+            throw new ResourceExistsException("이미 존재하는 아이디 입니다.");
         }
         return userRepository.save(dto.toEntity(passwordEncoder));
     }

--- a/src/main/resources/static/js/users/signup.js
+++ b/src/main/resources/static/js/users/signup.js
@@ -48,8 +48,8 @@ class Signup {
                 onSuccess: () => {
                     location.href = document.referrer;
                 },
-                onFailed: () => {
-                    this.errorBox.innerText = '입력 값을 다시 확인해주세요.';
+                onFailed: ({json}) => {
+                    this.errorBox.innerText = json.message;
                 },
                 onError: () => {
                     this.errorBox.innerText = '요청 중 문제가 발생하였습네다. 다시 요청해주세요.';

--- a/src/test/java/com/woowahan/techcamp/recipehub/user/controller/UserRestAcceptanceTest.java
+++ b/src/test/java/com/woowahan/techcamp/recipehub/user/controller/UserRestAcceptanceTest.java
@@ -142,6 +142,17 @@ public class UserRestAcceptanceTest extends AcceptanceTest {
     }
 
     @Test
+    public void signup_exist_email() {
+        SignupDTO dto = signupDTOBuilder.email(DEFAULT_USER_EMAIL).build();
+
+        ResponseEntity<RestResponse<User>> response = responseSignup(dto);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
+        assertThat(response.getBody().getMessage()).isEqualTo("이미 존재하는 아이디 입니다.");
+
+    }
+
+    @Test
     public void login() throws Exception {
         buildLoginRequest(DEFAULT_USER_EMAIL, DEFAULT_USER_PASSWORD)
                 .andExpect(status().isOk());

--- a/src/test/java/com/woowahan/techcamp/recipehub/user/service/UserServiceTest.java
+++ b/src/test/java/com/woowahan/techcamp/recipehub/user/service/UserServiceTest.java
@@ -1,6 +1,6 @@
 package com.woowahan.techcamp.recipehub.user.service;
 
-import com.woowahan.techcamp.recipehub.common.exception.ConflictException;
+import com.woowahan.techcamp.recipehub.common.exception.ResourceExistsException;
 import com.woowahan.techcamp.recipehub.common.exception.UnauthorizedException;
 import com.woowahan.techcamp.recipehub.user.domain.User;
 import com.woowahan.techcamp.recipehub.user.dto.LoginDTO;
@@ -48,7 +48,7 @@ public class UserServiceTest {
     }
 
     @Test
-    public void add() {
+    public void create() {
         when(passwordEncoder.encode(anyString())).thenReturn("encodedPassword");
         User user = signupDto.toEntity(passwordEncoder);
 
@@ -56,7 +56,7 @@ public class UserServiceTest {
         assertThat(userService.create(signupDto)).isEqualTo(user);
     }
 
-    @Test(expected = ConflictException.class)
+    @Test(expected = ResourceExistsException.class)
     public void duplicatedEmail() {
         when(userRepository.existsByEmail(anyString())).thenReturn(true);
         signupDto.setEmail("ming@woowahan.com");


### PR DESCRIPTION
- Add error message for existing email when signup
- Rename ConflictException to ResourceExistsException
- Add annotations to ControllerAdvice & RestControllerAdvice
  to separate web and api excpetion handling
- Change category not found exception
- Add slf4j annotation

Resolves: #72 