### PR TITLE
feat: Add handlebars helpers

### DIFF
--- a/src/main/java/com/woowahan/techcamp/recipehub/common/config/HandlebarsConfig.java
+++ b/src/main/java/com/woowahan/techcamp/recipehub/common/config/HandlebarsConfig.java
@@ -1,0 +1,27 @@
+package com.woowahan.techcamp.recipehub.common.config;
+
+import com.github.jknack.handlebars.Options;
+import com.github.jknack.handlebars.TagType;
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.springframework.context.annotation.Configuration;
+import pl.allegro.tech.boot.autoconfigure.handlebars.HandlebarsHelper;
+
+import java.io.IOException;
+
+@Configuration
+public class HandlebarsConfig {
+
+    @HandlebarsHelper
+    public class EqualsHelper {
+        public Object eq(Object a, final Options options) throws IOException {
+            Object b = options.param(0, null);
+            boolean result = new EqualsBuilder().append(a, b).isEquals();
+            if (options.tagType == TagType.SECTION) {
+                return result ? options.fn() : options.inverse();
+            }
+            return result
+                    ? options.hash("yes", true)
+                    : options.hash("no", false);
+        }
+    }
+}


### PR DESCRIPTION
우리가 사용하고 있는 [handlebars-spring-boot-starter](https://github.com/allegro/handlebars-spring-boot-starter) 라는 라이브러리가,
[Handlebars.java](
https://github.com/allegro/handlebars-spring-boot-starter)를 Spring boot에서 조금 쓰기 쉽게 만들어 놓은건데요.

https://github.com/jknack/handlebars.java#conditional-helpers
https://github.com/jknack/handlebars.java/blob/master/handlebars/src/main/java/com/github/jknack/handlebars/helper/ConditionalHelpers.java#L33-L59
위 두개를 보시면 4.0.7 부터는 Conditional Helpers가 추가되었어요.

덕분에 eq.. 등등 쓸 수 있는데.

handlebars-spring-boot-starter에서 아직 Handlebars.java 4.0.6을 쓰고 버전 업 생각을 안해서..
[PR 날리고 왔어요.](https://github.com/allegro/handlebars-spring-boot-starter/pull/28)
정말 글자 몇 개 바꾼거라ㅋㅋㅋ PR 날린거 테스트 내놓으라하면 어쩌지... (심지어 테스트는 Groovy로 짜여져 있음🤯)

일단 저게 단기간 내에 머지 승인될거 같지가 않아서, (이래서 ⭐️ 많이 받은 라이브러리 써야합니다 ㅠ.ㅠ)
편하게 쓸 수 있게 우리 Config에 eq Helpers만 살포시 추가해놨어요.

https://github.com/jknack/handlebars.java/blob/3b702a4a8ffeb07e52867fdf1ab69c9c414ae973/handlebars/src/main/java/com/github/jknack/handlebars/helper/ConditionalHelpers.java#L40
여기 나온것처럼, 다음과 같이 쓰면 돼영
```
//Usage:
   
Render 'yes' or 'no':
  {{#eq a b}}
    yes
  {{else}}
    no
  {{/eq}}
 
Render 'true' or 'false':
  {{eq a b}}

Render 'y' or 'n':
  {{eq a b yes='y' no='n'}}
```