### PR TITLE
fix: Set exception advice order

### DIFF
--- a/src/main/java/com/woowahan/techcamp/recipehub/common/support/APIControllerAdvice.java
+++ b/src/main/java/com/woowahan/techcamp/recipehub/common/support/APIControllerAdvice.java
@@ -5,6 +5,8 @@ import com.woowahan.techcamp.recipehub.common.exception.ResourceExistsException;
 import com.woowahan.techcamp.recipehub.common.exception.UnauthorizedException;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.support.MessageSourceAccessor;
+import org.springframework.core.Ordered;
+import org.springframework.core.annotation.Order;
 import org.springframework.http.HttpStatus;
 import org.springframework.validation.FieldError;
 import org.springframework.validation.ObjectError;
@@ -21,6 +23,7 @@ import java.util.Optional;
 
 @Slf4j
 @RestControllerAdvice(annotations = RestController.class)
+@Order(Ordered.HIGHEST_PRECEDENCE)
 public class APIControllerAdvice {
 
     @Resource(name = "messageSourceAccessor")

--- a/src/main/java/com/woowahan/techcamp/recipehub/common/support/WebControllerAdvice.java
+++ b/src/main/java/com/woowahan/techcamp/recipehub/common/support/WebControllerAdvice.java
@@ -3,6 +3,8 @@ package com.woowahan.techcamp.recipehub.common.support;
 import com.woowahan.techcamp.recipehub.common.exception.BadRequestException;
 import com.woowahan.techcamp.recipehub.common.exception.UnauthorizedException;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.core.Ordered;
+import org.springframework.core.annotation.Order;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Controller;
 import org.springframework.validation.BindException;
@@ -15,6 +17,7 @@ import javax.persistence.EntityNotFoundException;
 
 @Slf4j
 @ControllerAdvice(annotations = Controller.class)
+@Order(Ordered.LOWEST_PRECEDENCE)
 public class WebControllerAdvice {
 
     @ExceptionHandler(BindException.class)


### PR DESCRIPTION
같은 scope의 advice끼리는 적용 순서가 Bean이 로딩된 순서(랜덤하다고 하는데 클래스 ABC순이었음)여서 스프링이 @Controller를 잡는 Advice를 먼저 올려버리면 @RestControllerAdvice가 작동하지 않았음
@RestController가 Controller + ResponseBody여서 Controller를 잡는 Advice에서 exception이 잡혀버림
우리는 RestControllerAdvice의 이름이 APIControllerAdvice고, ControllerAdvice의 이름이 WebControllerAdvice여서 오류가 안 나고 있었음

이름을 ZAPIControllerAdvice로 바꾸면 RestController에서 나는 Exception들이 모두 ControllerAdvice에서 잡히면서 테스트가 터지는 것 확인함

Order 어노테이션 달아서 해결함 